### PR TITLE
Fix for nightly

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -114,7 +114,8 @@ impl Grid {
         assert!(x < self.width);
         assert!(y < self.height);
         let idx = y * self.width + x;
-        *self.chars.get_mut(idx.to_uint().unwrap()) = c;
+        // *self.chars.get_mut(idx.to_uint().unwrap()) = c;
+        self.chars[idx.to_uint().unwrap()] = c;
     }
 
     pub fn exec(&mut self, command: &Command) {


### PR DESCRIPTION
Fix for rustc 0.13.0-nightly (d91a015ab 2014-11-14 23:37:27 +0000)
Fix is just a revert of 75ef6da668c07305ad74c29a30ea80b8a11aa84e .... :-/
